### PR TITLE
[9, 10주차]_이재만

### DIFF
--- a/10주차/BOJ_11047_동전0/BOJ_11047_동전0_이재만.java
+++ b/10주차/BOJ_11047_동전0/BOJ_11047_동전0_이재만.java
@@ -1,0 +1,21 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+        int[] coin = new int[N];
+        for (int i = N - 1; i >= 0; i--) {                  // 입력되는 동전의 종류를 내림차순으로 저장
+            coin[i] = Integer.parseInt(br.readLine());
+        }
+        int answer = 0;
+        for (int c : coin) {                                // 큰 동전부터 최대한 사용하여 K를 만듬
+            answer += K / c;
+            K %= c;
+        }
+        System.out.println(answer);
+    }
+}

--- a/10주차/BOJ_11047_동전0/BOJ_11047_동전0_이재만.py
+++ b/10주차/BOJ_11047_동전0/BOJ_11047_동전0_이재만.py
@@ -1,0 +1,8 @@
+N, K = map(int,input().split())
+coin = [int(input()) for _ in range(N)]
+coin.reverse()
+answer = 0
+for c in coin:
+    answer += K // c
+    K %= c
+print(answer)

--- a/10주차/BOJ_11399_ATM/BOJ_11399_ATM_이재만.java
+++ b/10주차/BOJ_11399_ATM/BOJ_11399_ATM_이재만.java
@@ -1,0 +1,13 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int N;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        int answer = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).sorted().map(x -> x * N--).sum();      // 오름차순 정렬 후 누적합의 합을 구해줌
+        System.out.println(answer);
+    }
+}

--- a/10주차/BOJ_11399_ATM/BOJ_11399_ATM_이재만.py
+++ b/10주차/BOJ_11399_ATM/BOJ_11399_ATM_이재만.py
@@ -1,0 +1,3 @@
+N = int(input())
+P = sorted(list(map(int, input().split())))
+print(sum([P[i] * (N - i) for i in range(N)]))

--- a/9주차/BOJ_10866_덱/BOJ_10866_덱_이재만.java
+++ b/9주차/BOJ_10866_덱/BOJ_10866_덱_이재만.java
@@ -1,0 +1,36 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        String[] Q = new String[20000];
+        int f = 9999, r = 9999;                                             // f : deque의 맨 앞 인덱스
+        StringBuffer answer = new StringBuffer();                           // r : deque의 맨 뒤 인덱스
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            String c = st.nextToken();
+            if (c.equals("push_front")) {                                       // front의 경우 f 위치에 넣어주고 f를 1감소
+                String v = st.nextToken();
+                Q[f--] = v;
+            } else if (c.equals("push_back")) {                                 // rear의 경우 r을 1증가시키고 그 위치에 넣어줌
+                String v = st.nextToken();
+                Q[++r] = v;
+            } else if (c.equals("pop_front")) {                                 // 요소를 빼줄때는 반대로 front의 경우 f를 1증가시킨 후 해당 요소 출력, 비었다면 -1
+                answer.append(f == r ? "-1" : Q[++f]).append("\n");
+            } else if (c.equals("pop_back")) {                                  // rear의 경우 요소 출력 후 r을 1감소, 비었다면 -1
+                answer.append(f == r ? "-1" : Q[r--]).append("\n");
+            } else if (c.equals("size")) {                                      // rear - front 인덱스 값이 size
+                answer.append(r - f).append("\n");
+            } else if (c.equals("empty")) {                                     // 두 인덱스값이 같다면 요소가 없음
+                answer.append(f == r ? "1\n" : "0\n");
+            } else if (c.equals("front")) {                                     // pop이 아닌 출력의 경우 pop과 같은 요소를 출력하고 인덱스는 그대로 둠
+                answer.append(f == r ? "-1" : Q[f + 1]).append("\n");
+            } else if (c.equals("back")) {
+                answer.append(f == r ? "-1" : Q[r]).append("\n");
+            }
+        }
+        System.out.println(answer);
+    }
+}

--- a/9주차/BOJ_10866_덱/BOJ_10866_덱_이재만.py
+++ b/9주차/BOJ_10866_덱/BOJ_10866_덱_이재만.py
@@ -1,0 +1,16 @@
+from collections import deque
+import sys
+input = sys.stdin.readline
+
+
+N = int(input())
+Q = deque()
+com = {'push_back': Q.append, 'push_front': Q.appendleft, 'pop_front': lambda: print(Q.popleft() if Q else -1), 'pop_back': lambda: print(Q.pop() if Q else -1),
+       'size': lambda: print(len(Q)), 'empty': lambda: print(0 if len(Q) else 1), 'front': lambda: print(Q[0] if Q else -1), 'back': lambda: print(Q[-1] if Q else -1)}
+
+for _ in range(N):
+    c = input().split()
+    if len(c) > 1:
+        com[c[0]](c[1])
+    else:
+        com[c[0]]()

--- a/9주차/BOJ_11866_요세푸스문제0/BOJ_11866_요세푸스문제0_이재만.java
+++ b/9주차/BOJ_11866_요세푸스문제0/BOJ_11866_요세푸스문제0_이재만.java
@@ -1,0 +1,23 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+        Deque<Integer> arr = new ArrayDeque<>();
+        for (int i = 1; i <= N; i++)                            // 순서대로 deque에 넣어줌
+            arr.add(i);
+        StringBuffer answer = new StringBuffer("<");
+        while (!arr.isEmpty()) {                                // 모든 사람이 제거될 때까지 반복
+            for (int i = 0; i < K - 1; i++)                         // K - 1명의 사람은 다시 맨 뒤에 붙임
+                arr.add(arr.poll());
+            answer.append(arr.poll()).append(", ");                 // K번째 사람은 제거하여 answer에 순차적으로 넣어줌
+        }
+        answer.delete(answer.length() - 2, answer.length());    // 마지막 구분자 제거
+        answer.append('>');
+        System.out.println(answer);
+    }
+}

--- a/9주차/BOJ_11866_요세푸스문제0/BOJ_11866_요세푸스문제0_이재만.py
+++ b/9주차/BOJ_11866_요세푸스문제0/BOJ_11866_요세푸스문제0_이재만.py
@@ -1,0 +1,10 @@
+from collections import deque
+
+
+N, K = map(int, input().split())
+arr = deque(range(1, N + 1))
+answer = []
+while arr:
+    arr.rotate(1 - K)
+    answer.append(str(arr.popleft()))
+print(f'<{", ".join(answer)}>')

--- a/9주차/BOJ_2164_카드2/BOJ_2164_카드2_이재만.java
+++ b/9주차/BOJ_2164_카드2/BOJ_2164_카드2_이재만.java
@@ -1,0 +1,17 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        Deque<Integer> card = new ArrayDeque<>();
+        for (int i = 1; i < N + 1; i++)         // 번호를 순서대로 card 에 추가
+            card.add(i);
+        while (card.size() > 1) {               // 카드가 1장 남을 때까지 버리고 마지막에 추가 반복
+            card.poll();
+            card.add(card.poll());
+        }
+        System.out.println(card.peek());
+    }
+}

--- a/9주차/BOJ_2164_카드2/BOJ_2164_카드2_이재만.py
+++ b/9주차/BOJ_2164_카드2/BOJ_2164_카드2_이재만.py
@@ -1,0 +1,5 @@
+N = int(input())
+card, i = list(range(1, N + 1)), -1
+while (i := i + 2) < len(card):
+    card.append(card[i])
+print(card[-1])


### PR DESCRIPTION
## BOJ_2164_카드2
> Java　　 (메모리 : 28936 KB 시간 : 208 ms)
> Python　(메모리 : 54532 KB 시간 : 204 ms)

- 번호 순서대로 deque에 추가
- deque에 첫 요소를 버리고 다시 첫 요소를 마지막에 추가
- 요소가 1개 남을 때까지 반복

<br>

## BOJ_10866_덱
> Java　　 (메모리 : 18436 KB 시간 : 192 ms)
> Python　(메모리 : 34128 KB 시간 : 72 ms)

- 최대 10000개의 명령이 있으므로 크기가 20000인 배열 생성
- front와 rear을 모두 중간 인덱스로 설정
- 인덱스를 이용하여 각각의 명령 구현

<br>

## BOJ_11866_요세푸스문제0
> Java　　 (메모리 : 14696 KB 시간 : 164 ms)
> Python　(메모리 : 34088 KB 시간 : 64 ms)

- deque에 순서대로 숫자를 넣어줌
- deque에 요소가 있는 동안 아래 행동 반복
    - deque의 맨 앞 요소를 맨 뒤에 추가하는 작업을 K - 1 번 반복
    - deque의 맨 앞 요소를 제거(answer에 기록)

<br>

## BOJ_11047_동전0
> Java　　 (메모리 : 14192 KB 시간 : 124 ms)
> Python　(메모리 : 31256 KB 시간 : 44 ms)

- 입력되는 동전을 내림차순 정렬하여 저장
- 값이 큰 동전부터 최대한 사용하여 목표 금액을 만듬



<br>

## BOJ_11399_ATM
> Java　　 (메모리 : 14560 KB 시간 : 140 ms)
> Python　(메모리 : 31256 KB 시간 : 44 ms)

- 오름차순 정렬하여 누적합의 합을 구해줌